### PR TITLE
Update ember_templates compilation

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -99,8 +99,11 @@ EmberGenerator.prototype.writeIndex = function writeIndex() {
 
   this.indexFile = this.appendScripts(this.indexFile, 'scripts/main.js', [
     'scripts/app.js',
-    'scripts/compiled-templates.js'
   ]);
+
+  this.indexFile = this.appendFiles(this.indexFile, 'js', 'scripts/templates.js', [
+    'scripts/compiled-templates.js'
+  ], null, '.tmp');
 };
 
 EmberGenerator.prototype.all = function all() {

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -276,6 +276,7 @@ module.exports = function (grunt) {
                 'compass'
             ],
             dist: [
+                'ember_templates',
                 'coffee',
                 'compass:dist',
                 'imagemin',
@@ -284,17 +285,17 @@ module.exports = function (grunt) {
             ]
         },
         ember_templates: {
-          compile: {
             options: {
-              templateName: function(sourceFile) {
-                var path_regex = new RegExp(yeomanConfig.app + "/templates/");
-                return sourceFile.replace(path_regex, '');
-              }
+                templateName: function (sourceFile) {
+                    var templatePath = yeomanConfig.app + '/templates/';
+                    return sourceFile.replace(templatePath, '');
+                }
             },
-            files: {
-              "<%%= yeoman.app %>/scripts/compiled-templates.js": "<%%= yeoman.app %>/templates/**/*.hbs"
+            dist: {
+                files: {
+                    '.tmp/scripts/compiled-templates.js': '<%%= yeoman.app %>/templates/{,*/}*.hbs'
+                }
             }
-          }
         }
 
     });


### PR DESCRIPTION
The ember template compilation output is currently written to the `app` folder which violates ye olde Yeoman rule to never change the `app` folder's content (and results in a dozens of jshint violations in subsequent grunt runs). 

Also, the compilation step was missing from the `build` meta-task, so templates weren't compiled before `usemin` was looking for them.

The compilation output is now written to `.tmp`, which works fine in server mode, but unfortunately requires a separate usemin build block until 2.0 enables a more flexible lookup configuration.
