### PR TITLE
Add support for deeply nested handlebars templates

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -301,7 +301,7 @@ module.exports = function (grunt) {
             },
             dist: {
                 files: {
-                    '.tmp/scripts/compiled-templates.js': '<%%= yeoman.app %>/templates/{,*/}*.hbs'
+                    '.tmp/scripts/compiled-templates.js': '<%%= yeoman.app %>/templates/{,**/}*.hbs'
                 }
             }
         }


### PR DESCRIPTION
Hi,

I run into a minor issue.

In my yeoman app, if I put handlebars templates into a second depth level of `app/templates`, they are not compiled into `compiled-templates.js`.

I mean that in this hierarchy, `C.hbs` is not processed but `A.hbs` and `B.hbs` are.

```
|- app
  |- templates
    |- A.hbs
    |- B
      |- B.hbs
      |- C
        |- C.hbs
```

I had to edit my `Gruntfile.js` as in the commit attached to this pull request to make this work.

IMHO, it should be the default.

Sincerely,
