### PR TITLE
Add grunt-neuter for managing multiple files. This also fixes #27 and closes #15

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -138,10 +138,8 @@ EmberGenerator.prototype.writeIndex = function writeIndex() {
 
   this.indexFile = this.appendScripts(this.indexFile, 'scripts/components.js', this.bowerScripts);
 
-  this.indexFile = this.appendFiles(this.indexFile, 'js', 'scripts/main.js', [
-    'scripts/app.js',
-    'scripts/compiled-templates.js'
-  ], null, ['app', '.tmp']);
+  this.indexFile = this.appendFiles(this.indexFile, 'js', 'scripts/templates.js', ['scripts/compiled-templates.js'], null, ['.tmp']);
+  this.indexFile = this.appendFiles(this.indexFile, 'js', 'scripts/main.js', ['scripts/combined-scripts.js'], null, ['.tmp']);
 };
 
 EmberGenerator.prototype.bootstrapJavaScript = function bootstrapJavaScript() {

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -40,11 +40,14 @@ module.exports = function (grunt) {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
                 tasks: ['compass:server']
             },
+            neuter: {
+              files: ['<%%= yeoman.app %>/scripts/{,*/}*.js'],
+              tasks: ['neuter', 'livereload']
+            },
             livereload: {
                 files: [
                     '<%%= yeoman.app %>/*.html',
                     '{.tmp,<%%= yeoman.app %>}/styles/{,*/}*.css',
-                    '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js',
                     '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
                 ],
                 tasks: ['livereload']
@@ -277,16 +280,19 @@ module.exports = function (grunt) {
             server: [
                 'ember_templates',
                 'coffee:dist',
-                'compass:server'
+                'compass:server',
+                'neuter:app'
             ],
             test: [
                 'coffee',
-                'compass'
+                'compass',
+                'neuter:app'
             ],
             dist: [
                 'ember_templates',
                 'coffee',
                 'compass:dist',
+                'neuter:app',
                 'imagemin',
                 'svgmin',
                 'htmlmin'
@@ -304,8 +310,13 @@ module.exports = function (grunt) {
                     '.tmp/scripts/compiled-templates.js': '<%%= yeoman.app %>/templates/{,*/}*.hbs'
                 }
             }
+        },
+        neuter: {
+          app: {
+              src: '<%%= yeoman.app %>/scripts/app.js',
+              dest: '.tmp/scripts/combined-scripts.js'
+          }
         }
-
     });
 
     grunt.renameTask('regarde', 'watch');

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -25,7 +25,8 @@
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
     "matchdep": "~0.1.1",
-    "grunt-ember-templates": "0.4.5"
+    "grunt-ember-templates": "0.4.5",
+    "grunt-neuter": "0.5.0"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title>Ember Starter Kit</title>
+        <title>Yeoman Ember Starter Kit</title>
     </head>
     <body>
 

--- a/app/templates/scripts/app.js
+++ b/app/templates/scripts/app.js
@@ -1,15 +1,19 @@
 /*global Ember */
 
-(function (window) {
-  var App = window.App = Ember.Application.create();
+var App = window.App = Ember.Application.create();
 
-  App.Router.map(function () {
-    // put your routes here
-  });
+/* Order and include as you please. */
+// require('app/scripts/routes/*');
+// require('app/scripts/controllers/*');
+// require('app/scripts/models/*');
+// require('app/scripts/views/*');
 
-  App.IndexRoute = Ember.Route.extend({
-    model: function () {
-      return ['red', 'yellow', 'blue'];
-    }
-  });
-})(this);
+App.Router.map(function () {
+  // put your routes here
+});
+
+App.IndexRoute = Ember.Route.extend({
+  model: function () {
+    return ['red', 'yellow', 'blue'];
+  }
+});


### PR DESCRIPTION
So a couple of changes in this PR. Firstly, I have included `grunt-neuter` for managing sub-folders in `scripts` like `models`, `routes` and so on. It's obviously much better than manually cluttering `app/index.html`.

In `app.js`, you can write something like `require('app/scripts/models/*')` to require all js files there or `require('app/scripts/models/**/*')` to require all js files in all sub directories. It wraps the content of each file in a function(can be configured) so no worries about leaks. This should be the first step towards sub-generators(coming soon :wink:)

I have also refactored `compiled-templates.js` from the `main.js` build block into it's own build block. It fixes #27

You will notice the livereload watcher no longer watches js files. There is a bug where two watchers cannot watch the same file as only one will get triggered. To cater for this, the neuter watcher watches js files and triggers the livereload task :thumbsup: 

So...... what do you guys think?

Cheers
