### PR TITLE
Upgrade ember and handlebars

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -24,9 +24,9 @@ module.exports = function (grunt) {
     grunt.initConfig({
         yeoman: yeomanConfig,
         watch: {
-            ember_templates: {
+            emberTemplates: {
                 files: '<%%= yeoman.app %>/templates/**/*.hbs',
-                tasks: ['ember_templates', 'livereload']
+                tasks: ['emberTemplates', 'livereload']
             },
             coffee: {
                 files: ['<%%= yeoman.app %>/scripts/{,*/}*.coffee'],
@@ -279,7 +279,7 @@ module.exports = function (grunt) {
         },
         concurrent: {
             server: [
-                'ember_templates',
+                'emberTemplates',
                 'coffee:dist',
                 'compass:server'
             ],
@@ -288,7 +288,7 @@ module.exports = function (grunt) {
                 'compass'
             ],
             dist: [
-                'ember_templates',
+                'emberTemplates',
                 'coffee',
                 'compass:dist',
                 'imagemin',
@@ -296,7 +296,7 @@ module.exports = function (grunt) {
                 'htmlmin'
             ]
         },
-        ember_templates: {
+        emberTemplates: {
             options: {
                 templateName: function (sourceFile) {
                     var templatePath = yeomanConfig.app + '/templates/';

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "dependencies": {
     "jquery": "~1.9.1",
-    "handlebars": "1.0.0-rc.3",
-    "ember": "1.0.0-rc.3"<% if (emberData) { %>,
+    "handlebars": "1.0.0-rc.4",
+    "ember": "1.0.0-rc.4"<% if (emberData) { %>,
     "ember-data-shim": "~0.0.12"<% } %><% if (compassBootstrap) { %>,
     "bootstrap-sass": "~2.3.1"<% } %>
   },

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -25,7 +25,7 @@
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
     "matchdep": "~0.1.1",
-    "grunt-ember-templates": "0.4.5",
+    "grunt-ember-templates": "0.4.7",
     "grunt-neuter": "0.5.0"
   },
   "engines": {


### PR DESCRIPTION
Upgrades Ember to RC4, Handlebars to RC4 and grunt-ember-templates to 0.4.7
