### PR TITLE
Tell jslint there's a global window object

### DIFF
--- a/app/templates/scripts/app.js
+++ b/app/templates/scripts/app.js
@@ -1,4 +1,5 @@
 /*global Ember<% if (emberData) {%>, DS<% } %> */
+/*jslint browser: true */
 
 var App = window.App = Ember.Application.create();
 


### PR DESCRIPTION
Currently jslint fails with:

> [L4:C11] W117: 'window' is not defined.
