### PR TITLE
Document Ruby and Compass dependencies in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,13 @@ Maintainer: [Anthony Bull](https://github.com/inkredabull)
 
 ## Usage
 
-First, if you have not installed yo yet via npm, do this:
+First, this generator requires that Ruby and Compass are installed and in your path.
+
+- `which ruby && which compass`
+
+If you do not see two paths, follow [these instructions](https://github.com/gruntjs/grunt-contrib-compass#compass-task).
+
+Second, if you have not installed yo yet via npm, do this:
 
 - `npm install -g yo grunt-cli bower`
 


### PR DESCRIPTION
My first attempt to use this generator was frustrated by a path issue (#69). This patch documents the generator's Ruby and Compass dependencies (which - as a newcomer to Compass and Ember - I was unaware of).
