### PR TITLE
[Fixes #84] grunt dist uses ember.prod and ember-data.prod

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -36,8 +36,8 @@ var EmberGenerator = module.exports = function EmberGenerator(args, options) {
   this.bowerScripts = [
     'bower_components/jquery/jquery.js',
     'bower_components/handlebars/handlebars.runtime.js',
-    'bower_components/ember/ember.js',
-    'bower_components/ember-data-shim/ember-data.js'
+    '@@ember',
+    '@@ember_data'
   ];
 
   this.on('end', function () {
@@ -138,7 +138,7 @@ EmberGenerator.prototype.writeIndex = function writeIndex() {
 
   this.indexFile = this.appendStyles(this.indexFile, 'styles/main.css', mainCssFiles);
 
-  this.indexFile = this.appendScripts(this.indexFile, 'scripts/components.js', this.bowerScripts);
+  this.indexFile = this.appendFiles(this.indexFile, 'js', 'scripts/components.js', this.bowerScripts, null, 'app');
 
   this.indexFile = this.appendFiles(this.indexFile, 'js', 'scripts/templates.js', ['scripts/compiled-templates.js'], null, '.tmp');
   this.indexFile = this.appendFiles(this.indexFile, 'js', 'scripts/main.js', ['scripts/combined-scripts.js'], null, '.tmp');
@@ -162,7 +162,7 @@ EmberGenerator.prototype.bootstrapJavaScript = function bootstrapJavaScript() {
     'bower_components/bootstrap-sass/js/scrollspy.js',
     'bower_components/bootstrap-sass/js/collapse.js',
     'bower_components/bootstrap-sass/js/tab.js'
-  ]);
+  ], null, 'app');
 };
 
 EmberGenerator.prototype.all = function all() {

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -209,7 +209,7 @@ module.exports = function (grunt) {
             }
         },
         useminPrepare: {
-            html: '<%%= yeoman.app %>/index.html',
+            html: '.tmp/index.html',
             options: {
                 dest: '<%%= yeoman.dist %>'
             }
@@ -271,6 +271,30 @@ module.exports = function (grunt) {
                     dest: '<%%= yeoman.dist %>'
                 }]
             }
+        },
+        replace: {
+          app: {
+            options: {
+              variables: {
+                ember: 'bower_components/ember/ember.js',
+                ember_data: 'bower_components/ember-data-shim/ember-data.js'
+              }
+            },
+            files: [
+              {src: '<%%= yeoman.app %>/index.html', dest: '.tmp/index.html'}
+            ]
+          },
+          dist: {
+            options: {
+              variables: {
+                ember: 'bower_components/ember/ember.prod.js',
+                ember_data: 'bower_components/ember-data-shim/ember-data.prod.js'
+              }
+            },
+            files: [
+              {src: '<%%= yeoman.app %>/index.html', dest: '.tmp/index.html'}
+            ]
+          }
         },
         // Put files not handled in other tasks here
         copy: {
@@ -359,6 +383,7 @@ module.exports = function (grunt) {
 
         grunt.task.run([
             'clean:server',
+            'replace:app',
             'concurrent:server',
             'neuter:app',
             'connect:livereload',
@@ -369,6 +394,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask('test', [
         'clean:server',
+        'replace:app',
         'concurrent:test',
         'connect:test',
         'neuter:app',<% if (options.karma) { %>
@@ -379,6 +405,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask('build', [
         'clean:dist',
+        'replace:dist',
         'useminPrepare',
         'concurrent:dist',
         'neuter:app',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -27,12 +27,12 @@
     "connect-livereload": "~0.2.0",
     "grunt-ember-templates": "0.4.14",
     "time-grunt": "~0.1.1",
+    "grunt-replace": "~0.4.4",
     "jshint-stylish": "~0.1.3",
     "grunt-neuter": "~0.5.0"<% if (options.karma) { %>,
     "grunt-karma": "~0.6.1", <% if (testFramework === 'mocha') { %>
     "karma-mocha": "~0.1"<% } else { %>
     "karma-jasmine": "~0.1" <% } } %>
-
   },
   "engines": {
     "node": ">=0.8.0"

--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -69,7 +69,7 @@ describe('Basics', function () {
     var expected = [
       [
         'app/index.html', 
-        /<script src="bower_components\/ember-data-shim\/ember-data.js"><\/script>/
+        /<script src="@@ember_data"><\/script>/
       ]
     ];
     this.ember.app.run({}, function () {


### PR DESCRIPTION
This PR uses the production builds of ember for `grunt build` task. I had to revert fetching ember and ember-data via bower, to receive the prod files. Currently bower has RC6.1, but I sent a PR with RC7 (https://github.com/components/ember/pull/34).

What do you think?
