### PR TITLE
Remove ember-data revision number

### DIFF
--- a/app/templates/scripts/store.coffee
+++ b/app/templates/scripts/store.coffee
@@ -1,3 +1,3 @@
 <%= _.classify(appname) %>.Store = DS.Store.extend {
-    # if you're looking at this, you probably know what you're doing...
+    adapter: DS.FixtureAdapter.create()
 }

--- a/app/templates/scripts/store.js
+++ b/app/templates/scripts/store.js
@@ -1,4 +1,3 @@
 <%= _.classify(appname) %>.Store = DS.Store.extend({
-  revision: 13,
-  adapter: DS.FixtureAdapter.create()
+    adapter: DS.FixtureAdapter.create()
 });


### PR DESCRIPTION
Since Ember Data 0.13 the API revision check has been removed.

You no longer need to provide the API revision number when defining your
store, see http://emberjs.com/blog/2013/05/28/ember-data-0-13.htmlhttp://emberjs.com/blog/2013/05/28/ember-data-0-13.html#toc_api-revision-removal
