### PR TITLE
Remove Unecessary File From App Generation

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,8 +10,6 @@ var EmberGenerator = module.exports = function EmberGenerator(args, options) {
     this.appname += '_app';
   }
 
-  this.hookFor('ember:router');
-
   // setup the test-framework property, Gruntfile template will need this
   this.testFramework = options['test-framework'] || 'mocha';
 

--- a/test/test-compass.js
+++ b/test/test-compass.js
@@ -15,7 +15,6 @@ var EXPECTED_FILES = [
   '.editorconfig',
   'Gruntfile.js',
   'app/scripts/app.js',
-  'app/scripts/router.js',
   'app/templates/application.hbs',
   'app/templates/index.hbs',
   'app/index.html'

--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -15,7 +15,6 @@ var EXPECTED_FILES = [
   '.editorconfig',
   'Gruntfile.js',
   'app/scripts/app.js',
-  'app/scripts/router.js',
   'app/scripts/store.js',
   'app/scripts/routes/application_route.js',
   'app/templates/application.hbs',
@@ -82,6 +81,7 @@ describe('Basics', function () {
     this.ember.app.options['coffee'] = true;
     this.ember.app.run({}, function () {
       assert.ok(fs.existsSync('app/scripts/app.coffee'));
+      assert.ok(!fs.existsSync('app/scripts/router.js'));
       done();
     });
   });


### PR DESCRIPTION
When the app generator was run in with `--coffee` there was a router.js file
being created in the repo. It looks like the router.js file is being generated
through the router/template rather than the app/template and there is no
coffeecript option for it. This was the simplest fix given the the router is not
strictly necessary for the application that is generated.

I also added a  test assertion to demonstrate that the router.js file wasn't created.
If you want to go a different direction on this, like creating a router.coffee file, I'd
be happy to look into that as well.
