### PR TITLE
more concise REST routes in router.js to close #131

### DIFF
--- a/router/index.js
+++ b/router/index.js
@@ -10,10 +10,10 @@ var RouterGenerator = module.exports = function RouterGenerator(args, options, c
   args.push('ember:router');
   yeoman.generators.NamedBase.apply(this, arguments);
 
-  this.options.controller_files = [];
-  this.options.controller_dir = 'app/scripts/controllers';
-  if (fs.existsSync(this.options.controller_dir)) {
-    this.controller_files = fs.readdirSync(this.options.controller_dir);
+  this.options.model_files = [];
+  this.options.model_dir = 'app/scripts/models';
+  if (fs.existsSync(this.options.model_dir)) {
+    this.model_files = fs.readdirSync(this.options.model_dir);
   }
   this.options.router_file = 'app/scripts/router.js';
 };
@@ -22,12 +22,12 @@ util.inherits(RouterGenerator, yeoman.generators.NamedBase);
 
 RouterGenerator.prototype.files = function files() {
   this.models = [];
-  var controllers = this.controller_files;
-  for (var i in controllers) {
-    var stripped = controllers[i].replace('_controller.js', '');
+  var models = this.model_files;
+  for (var i in models) {
+    var stripped = models[i].replace('_model.js', '');
     this.models.push({
       single: fleck.singularize(stripped),
-      plural: stripped
+      plural: fleck.pluralize(stripped)
     });
   }
   this.copy('base.js', this.options.router_file);

--- a/router/templates/base.js
+++ b/router/templates/base.js
@@ -1,7 +1,10 @@
 <%= _.classify(appname) %>.Router.map(function () {
   <% _.each(models, function(model, i) { %>
-  this.resource('<%= model.plural %>');
-  this.resource('<%= model.single %>', { path: '/<%= model.single %>/:<%= model.single %>_id' });
-  this.resource('<%= model.single %>.edit', { path: '/<%= model.single %>/:<%= model.single %>_id/edit' });
+  this.resource('<%= model.plural %>', function(){
+    this.resource('<%= model.single %>', { path: '/:<%= model.single %>_id' }, function(){
+      this.route('edit');
+    });
+    this.route('create');
+  });
   <% }); %>
 });

--- a/test/test-model.js
+++ b/test/test-model.js
@@ -57,7 +57,6 @@ describe('Model', function () {
       helpers.assertFiles( [ router.options.router_file ] );
       helpers.assertFile(router.options.router_file, /resource\('users'/);
       helpers.assertFile(router.options.router_file, /resource\('user'/);
-      helpers.assertFile(router.options.router_file, /resource\('user.edit'/);
       done();
     });
   });


### PR DESCRIPTION
Currently, REST routes generated by `yo ember:model` produce the following:

``` javascript
App.Router.map(function () {

  this.resource('user_edit');
  this.resource('user_edit', { path: '/user_edit/:user_edit_id' });
  this.resource('user_edit.edit', { path: '/user_edit/:user_edit_id/edit' });

  this.resource('users');
  this.resource('user', { path: '/user/:user_id' });
  this.resource('user.edit', { path: '/user/:user_id/edit' });

});
```

Whereas [An In-depth Introduction to Ember.js](http://coding.smashingmagazine.com/2013/11/07/an-in-depth-introduction-to-ember-js/#instantiate_the_router) recommends the more concise:

``` javascript
App.Router.map(function(){
  this.resource('users', function(){
    this.resource('user', { path:'/:user_id' }, function(){
      this.route('edit');
    });
    this.route('create');
  });
});
```

This commit changes `router.js` to generate routes with the later convention.

The only tricky part of this commit was changing `router/index.js` to get the list of model names from files in `app/scripts/models` instead of `app/scripts/controllers/` to prevent separate routes for `user_edit`.
