### PR TITLE
Edit view input boxes

### DIFF
--- a/controller/templates/base_edit.coffee
+++ b/controller/templates/base_edit.coffee
@@ -1,6 +1,9 @@
 <%= _.classify(appname) %>.<%= _.classify(name) %>EditController = Ember.ObjectController.extend(
-  save: ->
-    # we're cheating here that there's no commit()
-    # but the UI element is already bound to the model
-    @transitionToRoute '<%= name.toLowerCase() %>', @get('model')
+  needs: '<%=name.toLowerCase()%>'
+  actions:
+    save: ->
+      self = this
+      @get('buffer').forEach (attr)->
+        self.get('controllers.<%=name.toLowerCase()%>.model').set(attr.key, attr.value)
+      @transitionToRoute '<%= name.toLowerCase() %>', @get('model')
 )

--- a/controller/templates/base_edit.js
+++ b/controller/templates/base_edit.js
@@ -1,8 +1,13 @@
 <%= _.classify(appname) %>.<%= _.classify(name) %>EditController = Ember.ObjectController.extend({
-  save: function(){
-    // we're cheating here that there's no commit()
-    // but the UI element is already bound to the model
-    this.transitionToRoute('<%= name.toLowerCase() %>',this.get('model'));
+  needs: '<%= name.toLowerCase() %>',
+  actions: {
+    save: function(){
+      self = this
+      this.get('buffer').forEach(function(attr){
+        self.get('controllers.<%=name.toLowerCase()%>.model').set(attr.key, attr.value);
+      });
+      this.transitionToRoute('<%=name.toLowerCase()%>',this.get('model'));
+    }
   }
 });
 

--- a/controller/templates/single_edit_route.coffee
+++ b/controller/templates/single_edit_route.coffee
@@ -1,5 +1,10 @@
 <%= _.classify(appname) %>.<%= _.classify(name) %>EditRoute = Ember.Route.extend(
-  model: (model) ->
-    @get('store').find('<%= _.slugify(name) %>', model.<%= _.slugify(name) %>_id)
+  model: (params) ->
+    @get('store').find('<%= _.slugify(name) %>', @modelFor('<%= _.slugify(name) %>').id)
+  setupController: (controller, model) ->
+    controller.set 'model', model
+    buffer = model.get('attributes').map (attr)->
+      { key: attr.get('key'), value: attr.get('value') }
+    controller.set 'buffer', buffer
 )
 

--- a/controller/templates/single_edit_route.js
+++ b/controller/templates/single_edit_route.js
@@ -1,6 +1,13 @@
 <%= _.classify(appname) %>.<%= _.classify(name) %>EditRoute = Ember.Route.extend({
-  model: function(model) {
-    return this.get('store').find('<%= _.slugify(name) %>', model.<%= _.slugify(name) %>_id);
+  model: function(params) {
+    return this.get('store').find('<%= _.slugify(name) %>', this.modelFor('<%= _.slugify(name)%>').id);
+  },
+  setupController: function(controller, model){
+    controller.set('model', model);
+    buffer = model.get('attributes').map(function(attr){
+      return { key: attr.get('key'), value: attr.get('value') }
+    });
+    controller.set('buffer', buffer)
   }
 });
 

--- a/controller/templates/single_route.coffee
+++ b/controller/templates/single_route.coffee
@@ -1,5 +1,5 @@
 <%= _.classify(appname) %>.<%= _.classify(name) %>Route = Ember.Route.extend(
-  model: (model) ->
-    @get('store').find('<%= _.slugify(name) %>', model.<%= _.slugify(name) %>_id)
+  model: (params) ->
+    @get('store').find('<%= _.slugify(name) %>', params.<%= _.slugify(name) %>_id)
 )
 

--- a/controller/templates/single_route.js
+++ b/controller/templates/single_route.js
@@ -1,6 +1,6 @@
 <%= _.classify(appname) %>.<%= _.classify(name) %>Route = Ember.Route.extend({
-  model: function(model) {
-    return this.get('store').find('<%= _.slugify(name) %>', model.<%= _.slugify(name) %>_id);
+  model: function(params) {
+    return this.get('store').find('<%= _.slugify(name) %>', params.<%= _.slugify(name) %>_id);
   }
 });
 

--- a/model/index.js
+++ b/model/index.js
@@ -30,5 +30,5 @@ ModelGenerator.prototype._getJSPath = function _getJSPath(file) {
 };
 
 ModelGenerator.prototype.files = function files() {
-  this.copy(this._getJSPath('base'), 'app/scripts/models/' + this._.slugify(this.name) + this._getJSPath('_model'));
+  this.template(this._getJSPath('base'), 'app/scripts/models/' + this._.slugify(this.name) + this._getJSPath('_model'));
 };

--- a/model/templates/base.coffee
+++ b/model/templates/base.coffee
@@ -1,25 +1,20 @@
-<%= _.classify(appname) %>.<%= _.classify(name) %> = DS.Model.extend(
+<%= _.classify(appname) %>.<%= _.classify(name) %> = DS.Model.extend
   <% _.each(attrs, function(attr, i) {  %>
-    <%= _.camelize(attr.name) %>: DS.attr('<%= attr.type %>')<% if(i < (attributes.length - 1)) { %>,<% } %>
-  <% }); %>
-)
+    <%= _.camelize(attr.name) %>: DS.attr('<%= attr.type %>')
+    <%})%>
 
 # probably should be mixed-in...
 <%= _.classify(appname) %>.<%= _.classify(name) %>.reopen
   # certainly I'm duplicating something that exists elsewhere...
   attributes: ( ->
-    attrs = []
-    Ember.$.each Ember.keys(@get('data')), (idx, key) =>
-      pair = key: key, value: @get(key)
-      attrs.push(pair)
-    attrs
+    model = this
+    Em.keys(@get('data')).map (key)->
+      Em.Object.create(model: model, key: key, valueBinding: 'model.' + key)
   ).property()
 
 # delete below here if you do not want fixtures
 <%= _.classify(appname) %>.<%= _.classify(name) %>.FIXTURES = [
 <% var ids = [1,2]; _.each(ids, function(idx, id) { %>
-  id: <%= id %><% _.each(attrs, function(attr, i) { %>
-  <%= attr.name %>: 'foo'<% }); %>
-  <% if(id < (ids.length - 1)) { %>,<% } %>
+  { id: <%= id %>, <% _.each(attrs, function(attr, i) { %> <%= attr.name %>: 'foo',<%});%> },
 <% }); %>
 ]

--- a/model/templates/base.js
+++ b/model/templates/base.js
@@ -6,13 +6,10 @@
 // probably should be mixed-in...
 <%= _.classify(appname) %>.<%= _.classify(name) %>.reopen({
   attributes: function(){
-    var attrs = [];
     var model = this;
-    Ember.$.each(Ember.keys(this.get('data')), function(idx, key){
-      var pair = { key: key, value: model.get(key) };
-      attrs.push(pair);
+    return Ember.keys(this.get('data')).map(function(key){
+      return Em.Object.create({ model: model, key: key, valueBinding: 'model.' + key });
     });
-    return attrs;
   }.property()
 });
 

--- a/test/helpers/expected_view_files.js
+++ b/test/helpers/expected_view_files.js
@@ -1,5 +1,4 @@
 JS_FILES_GENERATED_BY_VIEW_SUBGEN = [
-  'app/scripts/views/bound_text_field_view.js',
   'app/scripts/views/user_view.js',
   'app/scripts/views/user_edit_view.js',
   'app/scripts/views/users_view.js',
@@ -9,7 +8,6 @@ JS_FILES_GENERATED_BY_VIEW_SUBGEN = [
 ];
 
 COFFEE_FILES_GENERATED_BY_VIEW_SUBGEN = [
-  'app/scripts/views/bound_text_field_view.coffee',
   'app/scripts/views/user_view.coffee',
   'app/scripts/views/user_edit_view.coffee',
   'app/scripts/views/users_view.coffee',

--- a/test/test-view.js
+++ b/test/test-view.js
@@ -32,7 +32,6 @@ describe('View', function () {
       helpers.assertFiles( JS_FILES_GENERATED_BY_VIEW_SUBGEN );
       helpers.assertFile('app/scripts/views/users_view.js', /UsersView/);
       helpers.assertFile('app/templates/users.hbs', /linkTo.*this/);
-      helpers.assertFile('app/scripts/views/bound_text_field_view.js', /BoundTextFieldView = Ember.TextField.extend/);
       done();
     });
   });
@@ -49,7 +48,6 @@ describe('View', function () {
       helpers.assertFiles( COFFEE_FILES_GENERATED_BY_VIEW_SUBGEN );
       helpers.assertFile('app/scripts/views/users_view.coffee', /UsersView/);
       helpers.assertFile('app/templates/users.hbs', /linkTo.*this/);
-      helpers.assertFile('app/scripts/views/bound_text_field_view.coffee', /BoundTextFieldView = Ember.TextField.extend/);
       done();
     });
   });

--- a/view/index.js
+++ b/view/index.js
@@ -28,5 +28,4 @@ ViewGenerator.prototype.files = function files() {
   this.copy('single.hbs', 'app/templates/' + this.slugified_name + '.hbs');
   this.copy('single_edit.hbs', 'app/templates/' + this.slugified_name + '/edit.hbs');
   this.copy('plural.hbs', 'app/templates/' + this._.slugify(this.pluralized_name) + '.hbs');
-  this.copy(this._getJSPath('bound_text_field_view'), this._getJSPath('app/scripts/views/bound_text_field_view'));
 };

--- a/view/templates/bound_text_field_view.coffee
+++ b/view/templates/bound_text_field_view.coffee
@@ -1,9 +1,0 @@
-<%= _.classify(appname) %>.BoundTextFieldView = Ember.TextField.extend(
-  valueBinding: 'content.value',
-  contentChanged: ( ->
-    @get('controller').get('model').set(
-      @get('content').key,
-      @get('content').value
-    )
-  ).observes('content.value')
-)

--- a/view/templates/bound_text_field_view.js
+++ b/view/templates/bound_text_field_view.js
@@ -1,9 +1,0 @@
-<%= _.classify(appname) %>.BoundTextFieldView = Ember.TextField.extend({
-  valueBinding: 'content.value',
-  contentChanged: function() {
-    this.get('controller').get('model').set(
-      this.get('content').key,
-      this.get('content').value
-    ); // ugly, but gets the job done
-  }.observes('content.value')
-});

--- a/view/templates/single_edit.hbs
+++ b/view/templates/single_edit.hbs
@@ -1,13 +1,13 @@
 <h1><%= name %></h1>
 
 <table>
-  {{#each model.attributes}}
+  {{#each buffer}}
   <tr>
     <td>
-      <strong>{{this.key}}:</strong>
+      <strong>{{key}}:</strong>
     </td>
     <td>
-      {{view <%= _.classify(appname) %>.BoundTextFieldView contentBinding="this"}}
+      {{input value=value}}
     </td>
   </tr>
   {{/each}}


### PR DESCRIPTION
Fixed the issue with text input boxes not showing in the edit template. This was due to an attempt to access the url parameters of the parent route from the child route, which Ember does not allow you to do directly.

In the process of fixing this, I also discovered that the way editing was working seemed a little shady. Basically any changes made to the text inputs were immediately triggering direct changes on the model. I am new to this kind of programming but this seemed undesirable. The "Update" button was misleading, because it didn't actually update anything-- all the updates were already made by the time it was pressed; all it did was switch routes. 

To fix this, I changed the underlying code to add a "buffer" to the edit controller that has all the same fields as the model. The TextFields are bound to the buffer rather than to the model itself, and the buffer is used to update the model when the "Update" button is pressed.

This removed the need for the `BoundTextFieldView`, which seemed like a kind of hack to implement the previous direct binding of edit text fields to model properties.  I've left the `BoundTextFieldView` files in in case I'm missing something, but they're no longer being used by anything (they've been replaced by standard Ember `TextField` views in the edit template).
