### PR TITLE
Replace the deprecated 'linkTo' helper with the recommended link-to helper

### DIFF
--- a/test/test-view.js
+++ b/test/test-view.js
@@ -31,7 +31,7 @@ describe('View', function () {
     this.view.run({}, function () {
       helpers.assertFiles( JS_FILES_GENERATED_BY_VIEW_SUBGEN );
       helpers.assertFile('app/scripts/views/users_view.js', /UsersView/);
-      helpers.assertFile('app/templates/users.hbs', /linkTo.*this/);
+      helpers.assertFile('app/templates/users.hbs', /link-to.*this/);
       done();
     });
   });
@@ -47,7 +47,7 @@ describe('View', function () {
     this.view.run({}, function () {
       helpers.assertFiles( COFFEE_FILES_GENERATED_BY_VIEW_SUBGEN );
       helpers.assertFile('app/scripts/views/users_view.coffee', /UsersView/);
-      helpers.assertFile('app/templates/users.hbs', /linkTo.*this/);
+      helpers.assertFile('app/templates/users.hbs', /link-to.*this/);
       done();
     });
   });

--- a/view/templates/plural.hbs
+++ b/view/templates/plural.hbs
@@ -2,7 +2,7 @@
 
 <ul>
  {{#each model}}
- <li>{{#linkTo '<%= slugified_name %>' this}}{{this.id}}{{/linkTo}}</li>
+ <li>{{#link-to '<%= slugified_name %>' this}}{{this.id}}{{/link-to}}</li>
   {{/each}}
 </ul>
 

--- a/view/templates/single.hbs
+++ b/view/templates/single.hbs
@@ -13,6 +13,6 @@
   {{/each}}
 </table>
 
-{{#linkTo '<%= slugified_name %>.edit' model}}Change{{/linkTo}}
+{{#link-to '<%= slugified_name %>.edit' model}}Change{{/link-to}}
 
 {{outlet}}


### PR DESCRIPTION
The deprecated helper 'linkTo' has been renamed to 'link-to'. The linkTo helper has been renamed since Ember 1.0.0-rc.8 and throws a warning since 1.2.0. It is a deprecated helper.
