### PR TITLE
upgrade ember-data-shim to 1.0.0.beta.4

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "ember": "1.2.0",
-    "ember-data-shim": "1.0.0-beta.2"<% if (compassBootstrap) { %>,
+    "ember-data-shim": "1.0.0-beta.4"<% if (compassBootstrap) { %>,
     "bootstrap-sass": "~3.0.0"
     <% } %>
   },

--- a/app/templates/scripts/store.coffee
+++ b/app/templates/scripts/store.coffee
@@ -1,2 +1,1 @@
-<%= _.classify(appname) %>.Store = DS.Store.extend()
 <%= _.classify(appname) %>.ApplicationAdapter = DS.FixtureAdapter

--- a/app/templates/scripts/store.js
+++ b/app/templates/scripts/store.js
@@ -1,2 +1,1 @@
-<%= _.classify(appname) %>.Store = DS.Store.extend();
 <%= _.classify(appname) %>.ApplicationAdapter = DS.FixtureAdapter;


### PR DESCRIPTION
I had some issues getting ember data to work with 1.0.0.beta.2, with exceptions when calling `this.store.find('model_name')` in the routes.

Upgrading to ember-data 1.0.0.beta.4 fixed this for me. The pull request updates the necessary files and removes  no longer current ember-data store setup.
