### PR TITLE
Gruntfile.js - template folder structure - A question of design

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -341,8 +341,8 @@ module.exports = function (grunt) {
         emberTemplates: {
             options: {
                 templateName: function (sourceFile) {
-                    var templatePath = yeomanConfig.app + '/templates/';
-                    return sourceFile.replace(templatePath, '');
+                    // Removes the path and returns the actual templateName
+                    return sourceFile.replace(/^.*[\\\/]/, '');
                 }
             },
             dist: {


### PR DESCRIPTION
Accepting this should not be obvious, its a choice:

As it is now:
A template placed within the folder Templates/HelpTemplates/home.hbs should be referenced with "HelpTemplates/home"

Accepting the PR means:
A template placed within the folder Templates/HelpTemplates/home.hbs should be referenced with "home"
