### PR TITLE
Automate usage of Fonts by Bootstrap and Font-Awesome. Fixes #164.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -304,8 +304,8 @@ module.exports = function (grunt) {
                         expand: true,
                         flatten: true,
                         filter: 'isFile',
-                        cwd: '<%= yeoman.app %>/bower_components/',
-                        dest: '<%= yeoman.app %>/styles/fonts/',
+                        cwd: '<%%= yeoman.app %>/bower_components/',
+                        dest: '<%%= yeoman.app %>/styles/fonts/',
                         src: [ 
                             'bootstrap-sass/dist/fonts/**', // Bootstrap
                             'font-awesome/fonts/**' // Font-Awesome

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -298,6 +298,21 @@ module.exports = function (grunt) {
         },
         // Put files not handled in other tasks here
         copy: {
+            fonts: {
+                files: [
+                    { 
+                        expand: true,
+                        flatten: true,
+                        filter: 'isFile',
+                        cwd: '<%= yeoman.app %>/bower_components/',
+                        dest: '<%= yeoman.app %>/styles/fonts/',
+                        src: [ 
+                            'bootstrap-sass/dist/fonts/**', // Bootstrap
+                            'font-awesome/fonts/**' // Font-Awesome
+                        ]
+                    }
+                ]
+            },
             dist: {
                 files: [
                     {
@@ -310,17 +325,6 @@ module.exports = function (grunt) {
                             '.htaccess',
                             'images/{,*/}*.{webp,gif}',
                             'styles/fonts/*'
-                        ]
-                    },
-                    { // Copy Fonts from Bower Components
-                        expand: true,
-                        flatten: true,
-                        filter: 'isFile',
-                        cwd: '<%%= yeoman.app %>',
-                        dest: '<%%= yeoman.dist %>/styles/fonts/',
-                        src: [ 
-                            'bower_components/bootstrap-sass/dist/fonts/**', // Bootstrap
-                            'bower_components/font-awesome/fonts/**' // Font-Awesome
                         ]
                     }
                 ]
@@ -404,6 +408,7 @@ module.exports = function (grunt) {
             'replace:app',
             'concurrent:server',
             'neuter:app',
+            'copy:fonts',
             'connect:livereload',
             'open',
             'watch'

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -299,18 +299,31 @@ module.exports = function (grunt) {
         // Put files not handled in other tasks here
         copy: {
             dist: {
-                files: [{
-                    expand: true,
-                    dot: true,
-                    cwd: '<%%= yeoman.app %>',
-                    dest: '<%%= yeoman.dist %>',
-                    src: [
-                        '*.{ico,txt}',
-                        '.htaccess',
-                        'images/{,*/}*.{webp,gif}',
-                        'styles/fonts/*'
-                    ]
-                }]
+                files: [
+                    {
+                        expand: true,
+                        dot: true,
+                        cwd: '<%%= yeoman.app %>',
+                        dest: '<%%= yeoman.dist %>',
+                        src: [
+                            '*.{ico,txt}',
+                            '.htaccess',
+                            'images/{,*/}*.{webp,gif}',
+                            'styles/fonts/*'
+                        ]
+                    },
+                    { // Copy Fonts from Bower Components
+                        expand: true,
+                        flatten: true,
+                        filter: 'isFile',
+                        cwd: '<%%= yeoman.app %>',
+                        dest: '<%%= yeoman.dist %>/styles/fonts/',
+                        src: [ 
+                            'bower_components/bootstrap-sass/dist/fonts/**', // Bootstrap
+                            'bower_components/font-awesome/fonts/**' // Font-Awesome
+                        ]
+                    }
+                ]
             }
         },
         concurrent: {

--- a/app/templates/styles/style_bootstrap.scss
+++ b/app/templates/styles/style_bootstrap.scss
@@ -1,3 +1,4 @@
+$icon-font-path: "../styles/fonts/"; // Change the path to the fonts
 @import "bootstrap-sass/lib/bootstrap";
 
 /* Put your CSS here */


### PR DESCRIPTION
Fixes #164.

Works on both `dist` and normal mode.

---

Changes:
1. Added `Grunt` task `copy:fonts` that copies the Fonts from `<%= yeoman.app %>/bower_components/bootstrap-sass/dist/font/**` and `<%= yeoman.app %>/bower_components/font-awesome/fonts/**` to `<%= yeoman.app %>/styles/fonts/`
2. Added `copy:fonts` task to Grunt task `serve`. When passing the `dist` argument, it runs `copy` task with runs both `copy:fonts` and then `copy:dist` which will copy the fonts into `<%= yeoman.dist %>/styles/fonts/` directory.
