### PR TITLE
Fixed neuter-task to take path from yeomanConfig.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -372,7 +372,7 @@ module.exports = function (grunt) {
             app: {
                 options: {
                     filepathTransform: function (filepath) {
-                        return 'app/' + filepath;
+                        return yeomanConfig.app + '/' + filepath;
                     }
                 },
                 src: '<%%= yeoman.app %>/scripts/app.js',


### PR DESCRIPTION
Rather than having the fixed 'app' folder, which breaks the build-process if the paths are reconfigured.
