### PR TITLE
Fix incorrect loading of chai.js in grunt task

### DIFF
--- a/app/templates/karma.conf.js
+++ b/app/templates/karma.conf.js
@@ -23,7 +23,7 @@ module.exports = function(config) {
       'app/bower_components/ember/ember.js',
       'app/bower_components/ember-data/ember-data.js',
       <% if (testFramework === 'mocha') { %>
-      'test/bower_components/chai/chai.js',
+      'test/lib/chai.js',
       'app/bower_components/ember-mocha-adapter/adapter.js',
       <% } %>
       '.tmp/scripts/combined-scripts.js',


### PR DESCRIPTION
Bug introduced in Pull Request #169, 7d5871cb62c59a37f3b748a70ed510e62b57598a

The error this is solving occurs when $ grunt test is run. The output currently is:

WARN [watcher]: Pattern "#{app_dir}/test/bower_components/chai/chai.js" does not match any file.
INFO [Chrome 32.0.1700 (Mac OS X 10.9.0)]: Connected on socket 77vEg3nxwNCUOe-v8AXO
DEBUG: 'DEBUG: -------------------------------'
DEBUG: 'DEBUG: Ember : 1.3.1'
DEBUG: 'DEBUG: Ember Data : 1.0.0-beta.5'
DEBUG: 'DEBUG: Handlebars : 1.3.0'
DEBUG: 'DEBUG: jQuery : 2.0.3'
DEBUG: 'DEBUG: -------------------------------'
Chrome 32.0.1700 (Mac OS X 10.9.0) ERROR
Uncaught ReferenceError: chai is not defined
at #{app_dir}//test/support/initializer.js:6
