### PR TITLE
Fix compilation error on new --coffee project

### DIFF
--- a/app/templates/scripts/router.coffee
+++ b/app/templates/scripts/router.coffee
@@ -1,2 +1,2 @@
-<%= _.classify(appname) %>.Router - >
+<%= _.classify(appname) %>.Router ->
   # Add your routes here


### PR DESCRIPTION
The extra space causes `grunt test` to fail.
