### PR TITLE
Buggy test initialization

### DIFF
--- a/app/templates/test/_initializer.coffee
+++ b/app/templates/test/_initializer.coffee
@@ -12,7 +12,6 @@ Ember.Test.adapter = Ember.Test.MochaAdapter.create()
 
 <%= _.classify(appname) %>.setupForTesting()
 <%= _.classify(appname) %>.injectTestHelpers()
-Ember.run <%= _.classify(appname) %>, <%= _.classify(appname) %>.advanceReadiness
 
 window.start = ->
 window.stop = ->

--- a/app/templates/test/_initializer.js
+++ b/app/templates/test/_initializer.js
@@ -14,7 +14,6 @@ Ember.Test.adapter = Ember.Test.MochaAdapter.create();
 
 <%= _.classify(appname) %>.setupForTesting();
 <%= _.classify(appname) %>.injectTestHelpers();
-Ember.run(<%= _.classify(appname) %>, <%= _.classify(appname) %>.advanceReadiness);
 
 window.start = function () {};
 window.stop = function () {};


### PR DESCRIPTION
The test initializer was not up to date with [Ember Integration Testing Official Guide](http://emberjs.com/guides/testing/integration/). 
- Calls like `Ember.run` caused troubles while writing integration tests
- Test container creation in `_initializer.coffee` was not aligned with `_initializer.js`
- `Ember.testing = true` is useless, since `setupForTesting` handles everything for you
