### PR TITLE
Switch to official twitter bootstrap sass package

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -144,18 +144,18 @@ EmberGenerator.prototype.bootstrapJavaScript = function bootstrapJavaScript() {
   }
   // Wire Bootstrap plugins
   this.indexFile = this.appendScripts(this.indexFile, 'scripts/plugins.js', [
-    'bower_components/bootstrap-sass/js/affix.js',
-    'bower_components/bootstrap-sass/js/alert.js',
-    'bower_components/bootstrap-sass/js/dropdown.js',
-    'bower_components/bootstrap-sass/js/tooltip.js',
-    'bower_components/bootstrap-sass/js/modal.js',
-    'bower_components/bootstrap-sass/js/transition.js',
-    'bower_components/bootstrap-sass/js/button.js',
-    'bower_components/bootstrap-sass/js/popover.js',
-    'bower_components/bootstrap-sass/js/carousel.js',
-    'bower_components/bootstrap-sass/js/scrollspy.js',
-    'bower_components/bootstrap-sass/js/collapse.js',
-    'bower_components/bootstrap-sass/js/tab.js'
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/affix.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/alert.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/dropdown.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/tooltip.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/modal.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/transition.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/button.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/popover.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/carousel.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/scrollspy.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/collapse.js',
+    'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/tab.js'
   ], null, 'app');
 };
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -300,14 +300,14 @@ module.exports = function (grunt) {
         copy: {<% if (compassBootstrap) {%>
             fonts: {
                 files: [
-                    { 
+                    {
                         expand: true,
                         flatten: true,
                         filter: 'isFile',
                         cwd: '<%%= yeoman.app %>/bower_components/',
                         dest: '<%%= yeoman.app %>/styles/fonts/',
-                        src: [ 
-                            'bootstrap-sass/dist/fonts/**' // Bootstrap
+                        src: [
+                            'bootstrap-sass-official/vendor/assets/fonts/bootstrap/**' // Bootstrap
                         ]
                     }
                 ]

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -5,7 +5,7 @@
     "ember": "1.3.2",
     "handlebars": "1.2.1",
     "ember-data": "1.0.0-beta.5"<% if (compassBootstrap) { %>,
-    "bootstrap-sass": "~3.0.0"
+    "bootstrap-sass-official": "3.1.1"
     <% } %>
   },
   "resolutions": {

--- a/app/templates/styles/style_bootstrap.scss
+++ b/app/templates/styles/style_bootstrap.scss
@@ -1,5 +1,5 @@
 $icon-font-path: "../styles/fonts/"; // Change the path to the fonts
-@import "bootstrap-sass/lib/bootstrap";
+@import "bootstrap-sass-official/vendor/assets/stylesheets/bootstrap";
 
 /* Put your CSS here */
 html, body {


### PR DESCRIPTION
This pull request removes the deprecated `bootstrap-sass` package and switches to the official twitter bootstrap sass package `bootstrap-sass-official`.
#172
