### PR TITLE
Fix Karma's loading of CoffeeScript tests.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -157,9 +157,9 @@ module.exports = function (grunt) {
             test: {
                 files: [{
                     expand: true,
-                    cwd: 'test/spec',
+                    cwd: 'test',
                     src: '{,*/}*.coffee',
-                    dest: '.tmp/spec',
+                    dest: '.tmp/test',
                     ext: '.js'
                 }]
             }

--- a/app/templates/karma.conf.js
+++ b/app/templates/karma.conf.js
@@ -28,9 +28,9 @@ module.exports = function(config) {
       <% } %>
       '.tmp/scripts/combined-scripts.js',
       '.tmp/scripts/compiled-templates.js',<% if (options.coffee) { %>
-      'test/support/*.coffee',
-      'test/spec/*.coffee',
-      'test/integration/*.coffee'<% } else { %>
+      '.tmp/test/support/*.js',
+      '.tmp/test/spec/*.js',
+      '.tmp/test/integration/*.js'<% } else { %>
       'test/support/*.js',
       'test/spec/*.js',
       'test/integration/*.js'<% } %>


### PR DESCRIPTION
Fixes #197.

The one issue outstanding is the `test/spec/test.js` file that is generated. I do not know where that is coming from. It did not appear to be a template or copied file from the generator. Currently, in order for Karma to pick that spec file up, you must manually convert it to CoffeeScript after the generator completes.

What is generating that file? Is it is possible to have that file be generated as CoffeeScript?
