### PR TITLE
Forgotten hardcoded path to `app`

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -172,7 +172,7 @@ module.exports = function (grunt) {
                 imagesDir: '<%%= yeoman.app %>/images',
                 javascriptsDir: '<%%= yeoman.app %>/scripts',
                 fontsDir: '<%%= yeoman.app %>/styles/fonts',
-                importPath: 'app/bower_components',
+                importPath: '<%%= yeoman.app %>/bower_components',
                 httpImagesPath: '/images',
                 httpGeneratedImagesPath: '/images/generated',
                 httpFontsPath: '/styles/fonts',


### PR DESCRIPTION
This fixes error when Gruntfile was moved to root directory and yeoman.app changed accordingly:

```
Running "compass:dist" (compass) task
Errno::ENOENT on line ["33"] of /usr/local/Cellar/ruby193/1.9.3-p484/lib/ruby/gems/1.9.1/gems/compass-0.12.4/lib/compass/exec/global_options_parser.rb: No such file or directory - /Users/floatdrop/swarming/app
Run with --trace to see the full backtrace

Running "compass:server" (compass) task
Errno::ENOENT on line ["33"] of /usr/local/Cellar/ruby193/1.9.3-p484/lib/ruby/gems/1.9.1/gems/compass-0.12.4/lib/compass/exec/global_options_parser.rb: No such file or directory - /Users/floatdrop/swarming/app
Run with --trace to see the full backtrace
```
