### PR TITLE
pullout getJSPath

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,9 @@
 'use strict';
+
 var util = require('util');
 var path = require('path');
 var yeoman = require('yeoman-generator');
+var getJSPath = require('../utils/js_path');
 
 var EmberGenerator = module.exports = function EmberGenerator(args, options) {
   yeoman.generators.Base.apply(this, arguments);
@@ -41,9 +43,7 @@ var EmberGenerator = module.exports = function EmberGenerator(args, options) {
 
 util.inherits(EmberGenerator, yeoman.generators.Base);
 
-EmberGenerator.prototype._getJSPath = function _getJSPath(file) {
-  return file + (this.options.coffee ? '.coffee' : '.js');
-};
+EmberGenerator.prototype._getJSPath = getJSPath;
 
 EmberGenerator.prototype.welcome = function welcome() {
   // welcome message

--- a/controller/index.js
+++ b/controller/index.js
@@ -1,8 +1,10 @@
 'use strict';
+
 var util = require('util');
 var yeoman = require('yeoman-generator');
 var fs = require('fs');
 var fleck = require('fleck');
+var getJSPath = require('../utils/js_path');
 
 var ControllerGenerator = module.exports = function ControllerGenerator(args, options, config) {
   yeoman.generators.NamedBase.apply(this, arguments);
@@ -30,9 +32,7 @@ var ControllerGenerator = module.exports = function ControllerGenerator(args, op
 
 util.inherits(ControllerGenerator, yeoman.generators.NamedBase);
 
-ControllerGenerator.prototype._getJSPath = function _getJSPath(file) {
-  return file + (this.options.coffee ? '.coffee' : '.js');
-};
+ControllerGenerator.prototype._getJSPath = getJSPath;
 
 ControllerGenerator.prototype.files = function files() {
   this.template(this._getJSPath('base'), 'app/scripts/controllers/' + this._.slugify(this.name) + this._getJSPath('_controller'));

--- a/model/index.js
+++ b/model/index.js
@@ -1,6 +1,8 @@
 'use strict';
+
 var util = require('util');
 var yeoman = require('yeoman-generator');
+var getJSPath = require('../utils/js_path');
 
 var ModelGenerator = module.exports = function ModelGenerator(args, options, config) {
   yeoman.generators.NamedBase.apply(this, arguments);
@@ -25,9 +27,7 @@ var ModelGenerator = module.exports = function ModelGenerator(args, options, con
 
 util.inherits(ModelGenerator, yeoman.generators.NamedBase);
 
-ModelGenerator.prototype._getJSPath = function _getJSPath(file) {
-  return file + (this.options.coffee ? '.coffee' : '.js');
-};
+ModelGenerator.prototype._getJSPath = getJSPath;
 
 ModelGenerator.prototype.files = function files() {
   this.template(this._getJSPath('base'), 'app/scripts/models/' + this._.slugify(this.name) + this._getJSPath('_model'));

--- a/router/index.js
+++ b/router/index.js
@@ -1,8 +1,10 @@
 'use strict';
+
 var util = require('util');
 var yeoman = require('yeoman-generator');
 var fs = require('fs');
 var fleck = require('fleck');
+var getJSPath = require('../utils/js_path');
 
 var RouterGenerator = module.exports = function RouterGenerator(args, options, config) {
   // NamedBase needs a name, which is usually the first param passed in the script
@@ -29,9 +31,7 @@ var RouterGenerator = module.exports = function RouterGenerator(args, options, c
 
 util.inherits(RouterGenerator, yeoman.generators.NamedBase);
 
-RouterGenerator.prototype._getJSPath = function _getJSPath(file) {
-  return file + (this.options.coffee ? '.coffee' : '.js');
-};
+RouterGenerator.prototype._getJSPath = getJSPath;
 
 RouterGenerator.prototype.generateFiles = function generateFiles() {
   this.models = [];

--- a/utils/js_path.js
+++ b/utils/js_path.js
@@ -1,0 +1,3 @@
+module.exports = function getJSPath (file) {
+  return file + (this.options.coffee ? '.coffee' : '.js');
+};

--- a/view/index.js
+++ b/view/index.js
@@ -1,7 +1,9 @@
 'use strict';
+
 var util = require('util');
 var yeoman = require('yeoman-generator');
 var fleck = require('fleck');
+var getJSPath = require('../utils/js_path');
 
 var ViewGenerator = module.exports = function ViewGenerator(args, options, config) {
   yeoman.generators.NamedBase.apply(this, arguments);
@@ -17,9 +19,7 @@ var ViewGenerator = module.exports = function ViewGenerator(args, options, confi
 
 util.inherits(ViewGenerator, yeoman.generators.NamedBase);
 
-ViewGenerator.prototype._getJSPath = function _getJSPath(file) {
-  return file + (this.options.coffee ? '.coffee' : '.js');
-};
+ViewGenerator.prototype._getJSPath = getJSPath;
 
 ViewGenerator.prototype.files = function files() {
   this.copy(this._getJSPath('single'), 'app/scripts/views/' + this.slugified_name + this._getJSPath('_view'));


### PR DESCRIPTION
Moved it to `utils` folder, and require it for each generator..

Part of the general cleanup tasks in #144 
