### PR TITLE
updates grunt-neuter version from 0.5.0 to 0.6.0

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -29,7 +29,7 @@
     "time-grunt": "~0.1.1",
     "grunt-replace": "~0.4.4",
     "jshint-stylish": "~0.1.3",
-    "grunt-neuter": "~0.5.0"<% if (options.karma) { %>,
+    "grunt-neuter": "~0.6.0"<% if (options.karma) { %>,
     "grunt-karma": "~0.8.2",
     "karma-chrome-launcher": "~0.1.2", <% if (testFramework === 'mocha') { %>
     "karma-mocha": "~0.1.3"<% } else { %>


### PR DESCRIPTION
A problem I ran into with the old version (0.5.0) of grunt-neuter is not having the ability to have require statements without semicolons:

``` javascript
require('a')
require('b')
```

This wouldn't compile correctly unless I added semicolons:

``` javascript
require('a');
require('b');
```
