### PR TITLE
Changes the method call to wire bootstrap plugins

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -143,7 +143,7 @@ EmberGenerator.prototype.bootstrapJavaScript = function bootstrapJavaScript() {
     return;  // Skip if disabled.
   }
   // Wire Bootstrap plugins
-  this.indexFile = this.appendScripts(this.indexFile, 'scripts/plugins.js', [
+  this.indexFile = this.appendFiles(this.indexFile, 'js', 'scripts/plugins.js', [
     'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/affix.js',
     'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/alert.js',
     'bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/dropdown.js',


### PR DESCRIPTION
The method ´appendScripts´ has no parameter to handle the given searchPath (app) in the current version of generator-ember. This results in an empty `scripts/plugins.js` file if a user runs `grunt` or `grunt serve:dist`. To fix this issue I modified the generator to call the method `appendFiles` instead of `appendScripts`.
