### PR TITLE
added test/bower_components to gitignore template

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -4,3 +4,4 @@ dist
 .sass-cache
 .tmp
 app/bower_components
+test/bower_components


### PR DESCRIPTION
The test/bower_components dir shouldn't be included in source control.
