### PR TITLE
allow emberTemplates to compile nested templates

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -364,7 +364,7 @@ module.exports = function (grunt) {
             },
             dist: {
                 files: {
-                    '.tmp/scripts/compiled-templates.js': '<%%= yeoman.app %>/templates/{,*/}*.hbs'
+                    '.tmp/scripts/compiled-templates.js': '<%%= yeoman.app %>/templates/**/*.hbs'
                 }
             }
         },<% if (!options.coffee) { %>


### PR DESCRIPTION
{,*/} prevents deeply nested templates from having the right template name (e.g. the folder structure 'planbook/edit/basics' is converted to 'planbook/edit.basics')

*_._.hbs works correctly.
