### PR TITLE
Fix Karma reference to jQuery.

### DIFF
--- a/app/templates/karma.conf.js
+++ b/app/templates/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
 
     // List of files / patterns to load in the browser.
     files : [
-      'app/bower_components/jquery/jquery.min.js',
+      'app/bower_components/jquery/dist/jquery.min.js',
       'app/bower_components/handlebars/handlebars.runtime.js',
       'app/bower_components/ember/ember.js',
       'app/bower_components/ember-data/ember-data.js',


### PR DESCRIPTION
Off a fresh install, `grunt test` fails.

``` bash
Running "karma:unit" (karma) task
INFO [karma]: Karma v0.12.16 server started at http://localhost:9876/
INFO [launcher]: Starting browser Chrome
WARN [watcher]: Pattern "/Users/erictaylor/Documents/test-ember/app/bower_components/jquery/jquery.min.js" does not match any file.
WARN [watcher]: Pattern "/Users/erictaylor/Documents/test-ember/.tmp/test/spec/*.js" does not match any file.
INFO [Chrome 36.0.1985 (Mac OS X 10.9.3)]: Connected on socket W8PSYlIPKSxSYeDpxgrU with id 61192191
Chrome 36.0.1985 (Mac OS X 10.9.3) ERROR
  Uncaught Error: Could not find module jquery
  at /Users/erictaylor/Documents/test-ember/app/bower_components/ember/ember.js:251
```

`karma.config.js` references the old jquery location.

Updated `karma.config.js` to reference the updated `jquery.min.js` location.
