### PR TITLE
in hosted dev environments is necessary to listen to a specific port and IP

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -63,9 +63,9 @@ module.exports = function (grunt) {
         },
         connect: {
             options: {
-                port: 9000,
+                port: process.env.PORT || 9000,
                 // change this to '0.0.0.0' to access the server from outside
-                hostname: 'localhost'
+                hostname: process.env.IP || 'localhost'
             },
             livereload: {
                 options: {


### PR DESCRIPTION
This is e.g. true when running creating an ember app in Cloud9 IDE.

Usually port and ip are stored in the environment variables $PORT and $IP.
